### PR TITLE
Add Autodistill link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 [[`Project Page`](https://mmlab-ntu.github.io/project/edgesam/)]
 [[`Hugging Face Demo`](https://huggingface.co/spaces/chongzhou/EdgeSAM)]
 [[`iOS App (TBA)`]()]
+[[`Auto-Label Images with EdgeSAM`](https://github.com/autodistill/autodistill-grounded-edgesam)]
 
 https://github.com/chongzhou96/EdgeSAM/assets/15973859/fe1cd104-88dc-4690-a5ea-ff48ae013db3
 


### PR DESCRIPTION
Hello there! I am an engineer at [Roboflow](https://roboflow.com). We maintain [Autodistill](https:/github.com/autodistill/autodistill), a framework that enables you to use large foundation models to label data for use in training smaller vision models. I combined Grounding DINO and EdgeSAM to create Grounded EdgeSAM. This combination model allows for zero-shot prompting with Grounding DINO, then EdgeSAM creates masks. You can use this model to label images.

This PR adds a link to the Autodistill module so people can use it to auto-label data.