### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ https://github.com/chongzhou96/EdgeSAM/assets/15973859/fe1cd104-88dc-4690-a5ea-f
 
 ## Updates
 
-
+* **2023/12/16**: EdgeSAM is now supported in segmentation labeling tool [ISAT](https://github.com/yatengLG/ISAT_with_segment_anything)!
 * **2023/12/16**: EdgeSAM is now supported in [Grounded-Segment-Anything](https://github.com/IDEA-Research/Grounded-Segment-Anything). Check out the [grounded-edge-sam demo](https://github.com/IDEA-Research/Grounded-Segment-Anything/blob/main/EfficientSAM/grounded_edge_sam.py). Thanks to the IDEA Research team!
 * **2023/12/14**: [autodistill-grounded-edgesam](https://github.com/autodistill/autodistill-grounded-edgesam) combines Grounding DINO and EdgeSAM to create Grounded EdgeSAM [[blog](https://blog.roboflow.com/how-to-use-grounded-edgesam/)]. Thanks to the Roboflow team!
 * **2023/12/13**: Add ONNX export and speed up the web demo with ONNX as the backend.

--- a/segment_anything/modeling/rep_vit.py
+++ b/segment_anything/modeling/rep_vit.py
@@ -1,5 +1,5 @@
 import torch.nn as nn
-from segment_anything.modeling.common import LayerNorm2d, UpSampleLayer, OpSequential
+from .modeling.common import LayerNorm2d, UpSampleLayer, OpSequential
 
 __all__ = ['rep_vit_m1', 'rep_vit_m2', 'rep_vit_m3', 'RepViT']
 

--- a/segment_anything/predictor.py
+++ b/segment_anything/predictor.py
@@ -7,7 +7,7 @@
 import numpy as np
 import torch
 
-from segment_anything.modeling import Sam
+from .modeling import Sam
 
 from typing import Optional, Tuple
 


### PR DESCRIPTION
* 修复了包导入，存在的问题
如果环境中预先安装了SAM，下述包导入会默认从SAM导入，而非EdgeSAM
    
      predictor.py line 10
        from segment_anything.modeling.common import LayerNorm2d, UpSampleLayer, OpSequential

      rep_vit.py line 2
        from segment_anything.modeling import Sam

* 添加了到ISAT的链接
ISAT是一款基于SAM的半自动图像分割标注工具，目前已支持EdgeSAM。